### PR TITLE
feat: Add Brain Fog metric and update AI reflection logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             feeling: formData.get('feeling'),
             valuableDetour: formData.get('valuable-detour') === 'on',
             inventoryNote: formData.get('inventory-note'),
+            brainFog: formData.get('brain-fog'),
         };
 
         // Save and render the new "actual" locally first
@@ -91,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         aiOutputContainer.innerHTML = '';
 
         // 2. Create the journal entry string
-        let journalEntry = `Activity: ${newActual.title}, Time Spent: ${newActual.timeSpent} minutes. Feeling: ${newActual.feeling}.`;
+        let journalEntry = `Activity: ${newActual.title}, Time Spent: ${newActual.timeSpent} minutes. Feeling: ${newActual.feeling}. Brain Fog: ${newActual.brainFog}%.`;
         if (newActual.valuableDetour && newActual.inventoryNote) {
             journalEntry += ` Note: ${newActual.inventoryNote}`;
         }

--- a/index.html
+++ b/index.html
@@ -76,6 +76,10 @@
                             </div>
                         </div>
                         <div class="mb-4">
+                            <label for="brain-fog" class="block text-sm font-medium text-gray-700">Brain Fog Level: <span id="brain-fog-value">0</span>%</label>
+                            <input type="range" id="brain-fog" name="brain-fog" min="0" max="100" step="10" value="0" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                        </div>
+                        <div class="mb-4">
                             <label class="inline-flex items-center">
                                 <input type="checkbox" id="valuable-detour" name="valuable-detour" class="form-checkbox h-5 w-5 text-blue-600">
                                 <span class="ml-2 text-sm font-medium text-gray-700">Valuable Detour?</span>
@@ -142,6 +146,12 @@
             } else {
                 inventoryNoteContainer.classList.add('hidden');
             }
+        });
+
+        const brainFogSlider = document.getElementById('brain-fog');
+        const brainFogValue = document.getElementById('brain-fog-value');
+        brainFogSlider.addEventListener('input', () => {
+            brainFogValue.textContent = brainFogSlider.value;
         });
     </script>
 </body>

--- a/main.py
+++ b/main.py
@@ -69,13 +69,17 @@ task_ingest = Task(
 
 task_reflect = Task(
     description=(
-        "Based on the structured summary of the user's day, analyze the discrepancy between their intentions and actions. "
-        "If there was a 'detour,' formulate one or two gentle, Socratic questions to help the user find value in it. "
-        "For example: 'I notice you spent time on X instead of Y. What did X provide for you today that Y couldn't have?' "
-        "If the actions aligned with intentions, offer a brief, encouraging affirmation. "
-        "Frame your output as a supportive message directly to the user."
+        "Analyze the user's journal entry summary. Your primary focus is the 'Brain Fog' level.\n"
+        "1. **Acknowledge Brain Fog**: Start by mentioning the reported brain fog level.\n"
+        "2. **High Fog (>40%) Analysis**:\n"
+        "   - If they progressed on their intention, praise their resilience.\n"
+        "   - If they took a detour (e.g., rested), validate it as wise self-care, not a failure.\n"
+        "3. **Low Fog (<20%) Analysis**:\n"
+        "   - Focus on how their actions aligned with their goals.\n"
+        "4. **General Reflection**: For any other cases, or in addition to the above, you can still use gentle, Socratic questions to help the user find value in their day's activities.\n"
+        "Frame the entire output as a supportive, direct message to the user."
     ),
-    expected_output="A compassionate and insightful message for the user, containing either reflective questions or an affirmation.",
+    expected_output="A compassionate and insightful message for the user, that acknowledges their brain fog level and contains either reflective questions or an affirmation.",
     agent=reflection_agent,
     context=[task_ingest]
 )


### PR DESCRIPTION
This commit introduces a new 'Brain Fog' metric to the journaling application.

The changes include:
- A slider input for 'Brain Fog' (0-100) in the `index.html` form.
- Updated `app.js` to capture the brain fog level and include it in the journal entry sent to the backend.
- Modified the `reflection_agent`'s task description in `main.py` to use the brain fog level as the primary context for its analysis, providing more empathetic and relevant feedback to the user.