### PR TITLE
⚡ Bolt: Prevent Neo4j connection pool destruction on every request

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-04-16 - Neo4j Connection Pooling Performance Bottleneck
 **Learning:** Creating a new `GraphDatabase.driver` instance per function call defeats the built-in connection pooling mechanisms, causing a massive performance overhead in environments running multiple fast, concurrent queries.
 **Action:** Always wrap `GraphDatabase.driver` instances in a singleton pattern (or inject a shared instance) so the Neo4j Python driver can maintain and reuse its internal pool of connections. Remove manual `driver.close()` calls when using a singleton, and rely on `driver.session()` contexts to manage query lifecycles.
+
+## 2025-02-23 - Flask Teardown Destroying Connection Pools
+**Learning:** In Flask applications, `@app.teardown_appcontext` is executed at the end of every individual HTTP request. Binding `close_driver()` to this hook destroys the database connection pool after every request, negating any performance benefits of a global singleton and forcing expensive reconnections.
+**Action:** Never tie long-lived connection pool closures (like Neo4j drivers) to per-request teardown hooks in Flask. Let the driver singleton manage its own connection lifecycle globally across requests.

--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,6 @@ from flask import Flask
 from flask_cors import CORS
 from dotenv import load_dotenv
 
-from src.database.neo4j_client import close_driver
 
 # Add project root to Python path so imports work when run directly
 project_root = Path(__file__).parent.parent
@@ -72,10 +71,11 @@ def create_app():
 
     app = Flask(__name__)
 
-    @app.teardown_appcontext
-    def teardown_neo4j(exception):
-        """Ensure Neo4j driver is closed when application context ends."""
-        close_driver()
+    # ⚡ Bolt Optimization:
+    # Removed @app.teardown_appcontext hook for close_driver().
+    # Flask teardowns run at the end of every request. Closing the driver here
+    # destroys the Neo4j connection pool, forcing a costly reconnection for the next request.
+    # Allowing the global driver singleton to persist properly utilizes pooling.
 
     # --- CORS ---
     allowed_origins_str = os.environ.get(


### PR DESCRIPTION
💡 **What:** Removed `close_driver()` from Flask's `@app.teardown_appcontext` hook in `src/app.py`.
🎯 **Why:** Flask's teardown context executes at the end of every individual HTTP request. Because the Neo4j `GraphDatabase.driver` was being closed here, the application was destroying its global connection pool after every API call. This negated all benefits of the singleton connection manager and forced every subsequent request to establish a new connection from scratch, acting as a massive performance bottleneck. 
📊 **Impact:** Expect drastically reduced database latency across all API routes since the application will now properly reuse active connections in the pool rather than continuously authenticating and recreating them.
🔬 **Measurement:** Verify by running concurrent requests to any data-heavy endpoints (like `/api/journal/logs` or `/api/inventory/artifacts`) and comparing the response times before and after. Response times should be significantly lower and far more stable under load.

---
*PR created automatically by Jules for task [6635754383794440552](https://jules.google.com/task/6635754383794440552) started by @Zebfred*