### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-27 - Icon-only buttons lacking ARIA labels
+**Learning:** Found several icon-only buttons (like `&lt;` `&gt;` and `&times;` for calendar navigation and modal closing) that lacked accessibility context for screen readers.
+**Action:** Always verify that buttons containing only text-symbols or icons have a descriptive `aria-label` attribute so their function is clear to assistive technologies.

--- a/frontend/Adventure_Time_log.html
+++ b/frontend/Adventure_Time_log.html
@@ -14,12 +14,12 @@
         <!-- Monthly History Calendar Overlay -->
         <div id="monthly-history-calendar" class="max-w-4xl mx-auto mb-8 bg-white p-6 rounded-2xl shadow-md border border-gray-100 hidden lg:block">
             <div class="flex justify-between items-center mb-6">
-                <button id="prev-month-btn" class="text-gray-500 hover:text-blue-600 transition text-2xl font-bold px-4 py-2">&lt;</button>
+                <button id="prev-month-btn" aria-label="Previous month" class="text-gray-500 hover:text-blue-600 transition text-2xl font-bold px-4 py-2">&lt;</button>
                 <div class="text-center">
                     <h2 id="current-month-header" class="text-2xl font-extrabold text-gray-800 tracking-tight">Loading...</h2>
                     <p class="text-xs text-gray-500 font-medium tracking-widest uppercase mt-1">Historical Log Navigation</p>
                 </div>
-                <button id="next-month-btn" class="text-gray-500 hover:text-blue-600 transition text-2xl font-bold px-4 py-2">&gt;</button>
+                <button id="next-month-btn" aria-label="Next month" class="text-gray-500 hover:text-blue-600 transition text-2xl font-bold px-4 py-2">&gt;</button>
             </div>
             <div class="grid grid-cols-7 gap-2 mb-2 text-center font-bold text-gray-500 text-sm tracking-wider uppercase">
                 <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>

--- a/frontend/adventure_calendar.html
+++ b/frontend/adventure_calendar.html
@@ -34,8 +34,8 @@
                 <!-- Controls -->
                 <div class="flex items-center gap-3">
                     <button id="today-btn" class="bg-primary hover:bg-primary-hover text-on-primary font-bold py-2 px-4 rounded transition-colors text-sm shadow-sm hidden md:block">Today</button>
-                    <button id="prev-month-btn" class="bg-surface hover:bg-surface-hover border border-border text-main font-bold py-2 px-4 rounded transition-colors text-sm shadow-sm">◀</button>
-                    <button id="next-month-btn" class="bg-surface hover:bg-surface-hover border border-border text-main font-bold py-2 px-4 rounded transition-colors text-sm shadow-sm">▶</button>
+                    <button id="prev-month-btn" aria-label="Previous month" class="bg-surface hover:bg-surface-hover border border-border text-main font-bold py-2 px-4 rounded transition-colors text-sm shadow-sm">◀</button>
+                    <button id="next-month-btn" aria-label="Next month" class="bg-surface hover:bg-surface-hover border border-border text-main font-bold py-2 px-4 rounded transition-colors text-sm shadow-sm">▶</button>
                 </div>
             </div>
 
@@ -64,7 +64,7 @@
         <div class="bg-white p-6 rounded-2xl shadow-2xl max-w-lg w-full transform scale-95 transition-transform" id="day-modal-content">
             <div class="flex justify-between items-center border-b pb-3 mb-4">
                 <h3 class="text-2xl font-bold text-gray-800" id="modal-date-title">Date</h3>
-                <button id="close-modal-btn" class="text-gray-400 hover:text-red-500 text-2xl font-bold">&times;</button>
+                <button id="close-modal-btn" aria-label="Close" class="text-gray-400 hover:text-red-500 text-2xl font-bold">&times;</button>
             </div>
             <div id="modal-body" class="space-y-4 max-h-[60vh] overflow-y-auto pr-2 custom-scrollbar">
                 <!-- Day details dynamically injected here -->


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the "Previous Month", "Next Month", and "Close Modal" icon-only buttons across the application's calendar interfaces.
🎯 **Why**: To improve accessibility for users relying on screen readers, as buttons containing only text-symbols (like `<` or `&times;`) lack sufficient context for assistive technologies.
📸 **Before/After**: Visually identical, but the DOM now includes `aria-label="Previous month"`, `aria-label="Next month"`, and `aria-label="Close"`.
♿ **Accessibility**: Directly improves WCAG compliance by ensuring all interactive elements have accessible names.

---
*PR created automatically by Jules for task [14039617592002593123](https://jules.google.com/task/14039617592002593123) started by @Zebfred*