### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret fallback vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,8 @@
 **Vulnerability:** The `/wake_infrastructure` endpoint in `src/routes/admin_routes.py` lacked the `@require_api_key` decorator, allowing unauthenticated attackers to wake up cloud compute instances, potentially leading to denial-of-wallet (cost-based DoS) attacks.
 **Learning:** Endpoints that trigger actions with real-world cost implications (like waking compute resources) must be treated as sensitive and always protected behind robust authentication, even if they seem innocuous or are meant for "stealth" frontend triggers.
 **Prevention:** Ensure all administrative or operational endpoints have the `@require_api_key` or equivalent authentication decorator applied. Additionally, always test frontend integration of new authenticated endpoints using the designated secure fetch wrappers (e.g., `window.Auth.fetchWithAuth`).
+
+## 2026-05-06 - Hardcoded Cryptographic Secrets
+**Vulnerability:** The application used a hardcoded fallback (`default_dev_secret`) for `JWT_SECRET` when the environment variable was missing. This allows an attacker who knows the codebase to forge valid JWTs and bypass authentication if the production server was misconfigured.
+**Learning:** Cryptographic secrets and API keys must never have hardcoded default fallbacks in source code. Misconfigurations in the production environment should result in a secure, loud failure rather than silently relying on a known, insecure fallback.
+**Prevention:** Implement fail-secure patterns: check for the existence of required secrets via environment variables and, if missing, throw a critical error (e.g., 500 response or fail to start) to alert administrators immediately.

--- a/src/routes/admin_routes.py
+++ b/src/routes/admin_routes.py
@@ -180,8 +180,12 @@ def impersonate_user():
             return jsonify({"error": f"User {target_email} not found in database"}), 404
             
         profile_data = user_doc.get("profile", {})
-        jwt_secret = os.environ.get("JWT_SECRET", "default_dev_secret")
+        jwt_secret = os.environ.get("JWT_SECRET")
         
+        if not jwt_secret:
+            logger.error("CRITICAL SECURITY ERROR: JWT_SECRET environment variable is missing.")
+            return jsonify({"error": "Server configuration error"}), 500
+
         # Generate an impersonation JWT
         expiration = datetime.now(timezone.utc) + timedelta(hours=2) # Shorter duration for impersonation
         internal_token = jwt.encode(

--- a/src/routes/auth_routes.py
+++ b/src/routes/auth_routes.py
@@ -49,7 +49,11 @@ def login():
         
         # Read secrets
         google_client_id = os.environ.get("GOOGLE_CLIENT_USER_LOGIN_ID", "")
-        jwt_secret = os.environ.get("JWT_SECRET", "default_dev_secret")
+        jwt_secret = os.environ.get("JWT_SECRET")
+
+        if not jwt_secret:
+            logger.error("CRITICAL SECURITY ERROR: JWT_SECRET environment variable is missing.")
+            return jsonify({"error": "Server configuration error"}), 500
 
         if not google_client_id:
             logger.error("GOOGLE_CLIENT_USER_LOGIN_ID is not configured in the environment.")
@@ -127,7 +131,12 @@ def login_code():
             return jsonify({"error": "Google authorization code required"}), 400
             
         auth_code = data['code']
-        jwt_secret = os.environ.get("JWT_SECRET", "default_dev_secret")
+        jwt_secret = os.environ.get("JWT_SECRET")
+
+        if not jwt_secret:
+            logger.error("CRITICAL SECURITY ERROR: JWT_SECRET environment variable is missing.")
+            return jsonify({"error": "Server configuration error"}), 500
+
         paths = get_auth_paths()
 
         if not os.path.exists(paths["credentials"]):
@@ -226,7 +235,11 @@ def nexus_login():
         token_credential = data['credential']
         
         google_client_id = os.environ.get("GOOGLE_CLIENT_USER_LOGIN_ID", "")
-        jwt_secret = os.environ.get("JWT_SECRET", "default_dev_secret")
+        jwt_secret = os.environ.get("JWT_SECRET")
+
+        if not jwt_secret:
+            logger.error("CRITICAL SECURITY ERROR: JWT_SECRET environment variable is missing.")
+            return jsonify({"error": "Server configuration error"}), 500
 
         if not google_client_id:
             logger.error("GOOGLE_CLIENT_USER_LOGIN_ID is not configured in the environment.")
@@ -309,7 +322,12 @@ def nexus_login_code():
             return jsonify({"error": "Google authorization code required"}), 400
             
         auth_code = data['code']
-        jwt_secret = os.environ.get("JWT_SECRET", "default_dev_secret")
+        jwt_secret = os.environ.get("JWT_SECRET")
+
+        if not jwt_secret:
+            logger.error("CRITICAL SECURITY ERROR: JWT_SECRET environment variable is missing.")
+            return jsonify({"error": "Server configuration error"}), 500
+
         paths = get_auth_paths()
 
         if not os.path.exists(paths["credentials"]):


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: The application utilized a hardcoded fallback (`"default_dev_secret"`) for the `JWT_SECRET` environment variable across several authentication routes. 

🎯 **Impact**: If the application was deployed to a production environment where the `JWT_SECRET` variable was misconfigured or accidentally omitted, the server would silently fall back to this known secret. An attacker with access to the source code could use this default secret to forge valid JSON Web Tokens (JWTs), entirely bypassing the authentication layer and gaining unauthorized access to user or admin accounts.

🔧 **Fix**: Removed the `default_dev_secret` fallback from all `os.environ.get()` calls in `src/routes/auth_routes.py` and `src/routes/admin_routes.py`. Implemented a fail-secure mechanism: if `jwt_secret` evaluates to false/None, the route handler immediately logs a critical error (`logger.error("CRITICAL SECURITY ERROR: ...")`) and returns a generic 500 Internal Server Error (`{"error": "Server configuration error"}`) without leaking the exact failure cause to the client.

✅ **Verification**: 
- Utilized `py_compile` to verify syntax validity across `auth_routes.py` and `admin_routes.py`.
- Evaluated changes via explicit file inspection ensuring that `default_dev_secret` does not exist in these files anymore.
- Validated via grep that the fail-secure conditional block exists at every location `JWT_SECRET` is read. 

Also updated the `.jules/sentinel.md` journal with this critical security learning regarding hardcoded cryptographic secrets.

---
*PR created automatically by Jules for task [1707339871732853127](https://jules.google.com/task/1707339871732853127) started by @Zebfred*