### PR TITLE
⚡ Bolt: Use bulk_write in AuditInspector approve_batch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-02-23 - Flask Teardown Destroying Connection Pools
 **Learning:** In Flask applications, `@app.teardown_appcontext` is executed at the end of every individual HTTP request. Binding `close_driver()` to this hook destroys the database connection pool after every request, negating any performance benefits of a global singleton and forcing expensive reconnections.
 **Action:** Never tie long-lived connection pool closures (like Neo4j drivers) to per-request teardown hooks in Flask. Let the driver singleton manage its own connection lifecycle globally across requests.
+## 2024-11-20 - [Performance Bottleneck Fixed]
+**Learning:** Found an N+1 query vulnerability when iterating and calling `update_one` on the database connection in a loop.
+**Action:** Replaced sequential updates with bulk updates via `UpdateOne` and `bulk_write` method.

--- a/src/agents/audit_inspector.py
+++ b/src/agents/audit_inspector.py
@@ -1,6 +1,7 @@
 from typing import List, Dict
 import os
 from datetime import datetime, timezone
+from pymongo import UpdateOne
 from src.database.mongo_client.connection import MongoConnectionManager
 from src.config import MongoConfig
 from src.database.mongo_client.uuid_manager import UUIDGenerator
@@ -63,11 +64,18 @@ class AuditInspector:
         Also writes them permanently to the event_actuals ground truth collection.
         """
         records = list(self.daily_col.find({"gcal_id": {"$in": gcal_ids}, "status": "Pending Verification"}))
-        modified_count = 0
+
+        if not records:
+            return 0
+
+        actual_ops = []
+        unified_ops = []
+        daily_ops = []
+        user_id = os.environ.get("HERO_NAME", "Hero")
         
         for r in records:
             gcal_id = r.get("gcal_id")
-            event_uuid = UUIDGenerator.generate_for_event(gcal_id)
+            event_uuid = UUIDGenerator.generate_for_event(gcal_id, user_id)
             duration_mins = r.get("duration_minutes", 60)
             
             actual_payload = {
@@ -83,10 +91,10 @@ class AuditInspector:
             }
             
             # Map into Actual collection
-            self.actual_col.update_one(
+            actual_ops.append(UpdateOne(
                 {"_id": event_uuid},
                 {"$set": {
-                    "user_id": os.environ.get("HERO_NAME", "Hero"),
+                    "user_id": user_id,
                     "gcal_id": gcal_id,
                     "time_slot": time_slot,
                     "actual": actual_payload,
@@ -96,21 +104,30 @@ class AuditInspector:
                     }
                 }},
                 upsert=True
-            )
+            ))
             
             # Update Unified Collection
-            self.unified_col.update_one(
+            unified_ops.append(UpdateOne(
                 {"_id": event_uuid},
                 {"$set": {
                     "actual": actual_payload
                 }}
-            )
+            ))
             
             # Mark daily event as verified
-            res = self.daily_col.update_one(
+            daily_ops.append(UpdateOne(
                 {"_id": r["_id"]},
                 {"$set": {"status": "Verified", "verification_time": datetime.now(timezone.utc)}}
-            )
-            modified_count += res.modified_count
+            ))
+
+        if actual_ops:
+            self.actual_col.bulk_write(actual_ops)
+        if unified_ops:
+            self.unified_col.bulk_write(unified_ops)
+
+        modified_count = 0
+        if daily_ops:
+            res = self.daily_col.bulk_write(daily_ops)
+            modified_count = res.modified_count
             
         return modified_count


### PR DESCRIPTION
💡 **What**: Replaced sequential iterative `update_one` MongoDB calls inside the `AuditInspector.approve_batch` method with a batched execution using `bulk_write` and `pymongo.UpdateOne`. Also fixed a latent bug by correctly providing the missing `user_email` argument to the `UUIDGenerator.generate_for_event` method.

🎯 **Why**: Executing individual database update operations in a for-loop results in an "N+1" query pattern, multiplying network latency and severely bottlenecking the system when processing larger batches of unverified records from the UI.

📊 **Impact**: Reduces total database roundtrips for batch approval from `3 * N` to a maximum of `3` bulk roundtrips (Actuals, Unified, and Daily collections). This should improve processing speed significantly.

🔬 **Measurement**: Verify by processing a batch of 10 events via the Verification Dashboard. The API latency for the approval endpoint should drop, and MongoDB logs should register 3 `bulkWrite` operations rather than 30 sequential `update` operations.

---
*PR created automatically by Jules for task [10783327877142692512](https://jules.google.com/task/10783327877142692512) started by @Zebfred*