### PR TITLE
🎨 Palette: Make custom toggle & admin banner keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-04-27 - Icon-only buttons lacking ARIA labels
 **Learning:** Found several icon-only buttons (like `&lt;` `&gt;` and `&times;` for calendar navigation and modal closing) that lacked accessibility context for screen readers.
 **Action:** Always verify that buttons containing only text-symbols or icons have a descriptive `aria-label` attribute so their function is clear to assistive technologies.
+## 2024-05-18 - Fix custom toggle inputs visually hidden
+
+**Learning:** Custom UI toggle checkboxes visually hide the actual `<input>` using classes like `.sr-only`, breaking default keyboard focus rings.
+**Action:** When working with hidden form elements, ensure keyboard accessibility by targeting focus on the hidden input using the `:focus-visible` pseudo-class and applying styles to its visible sibling element (e.g., `#input:focus-visible + #visible-bg { outline: 2px solid; }`), and add ARIA attributes to describe its state.

--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -1,7 +1,7 @@
 <!-- Navbar -->
-<div id="impersonation-banner" class="bg-error text-on-primary text-center text-sm font-bold p-1 hidden cursor-pointer hover:opacity-90 transition" onclick="Auth.logout()">
+<button id="impersonation-banner" class="bg-error text-on-primary text-center text-sm font-bold p-1 hidden cursor-pointer hover:opacity-90 transition w-full block focus-visible:ring-2 focus-visible:outline-none" onclick="Auth.logout()" aria-label="Stop impersonating and return to Admin Hub">
     🛑 You are currently Impersonating a User (Shadow State). Click here to return to Admin Hub.
-</div>
+</button>
 <nav class="bg-nav p-4 text-surface shadow-md z-10 sticky top-0">
     <div class="container mx-auto flex justify-between items-center">
         <h1 class="text-2xl font-bold tracking-tight">Agentic Personal Porter</h1>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -20,6 +20,11 @@
             color: #f3f4f6;
             box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
         }
+
+        #analytics-toggle:focus-visible + #analytics-bg {
+            outline: 2px solid #2563eb;
+            outline-offset: 2px;
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
@@ -89,18 +94,18 @@
                 
                 <div class="flex items-center justify-between p-4 bg-white rounded-lg border">
                     <div>
-                        <h5 class="font-bold text-gray-800">Share Telemetry & Analytics</h5>
-                        <p class="text-sm text-gray-500 mt-1">Allow the system administrator to view your detailed metrics to improve orchestration and graph logic.</p>
+                        <h5 id="telemetry-title" class="font-bold text-gray-800">Share Telemetry & Analytics</h5>
+                        <p id="telemetry-desc" class="text-sm text-gray-500 mt-1">Allow the system administrator to view your detailed metrics to improve orchestration and graph logic.</p>
                     </div>
                     <label class="flex items-center cursor-pointer">
                         <div class="relative">
-                            <input type="checkbox" id="analytics-toggle" class="sr-only">
+                            <input type="checkbox" id="analytics-toggle" class="sr-only" aria-labelledby="telemetry-title" aria-describedby="telemetry-desc">
                             <div class="block bg-gray-300 w-14 h-8 rounded-full transition" id="analytics-bg"></div>
                             <div class="dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition transform" id="analytics-dot"></div>
                         </div>
                     </label>
                 </div>
-                <div id="analytics-status-msg" class="hidden mt-3 text-sm font-medium transition-opacity"></div>
+                <div id="analytics-status-msg" class="hidden mt-3 text-sm font-medium transition-opacity" role="status" aria-live="polite"></div>
             </section>
         </div>
     </main>


### PR DESCRIPTION
💡 **What:** 
Added screen reader and keyboard accessibility support to the custom telemetry toggle in `profile.html` and the shadow-state admin impersonation banner in `navbar.html`.

🎯 **Why:** 
Custom UI toggle checkboxes visually hide the actual `<input>` using classes like `.sr-only`, which breaks default keyboard focus rings and leaves screen readers without context. Furthermore, interactive banners utilizing `div` tags lack native keyboard support.

📸 **Before/After:**
*(Visuals verified via Playwright run — see attached video verification).*
The toggle now has a distinct blue focus ring when navigated via keyboard. The impersonation banner natively handles tab-focus and Space/Enter key presses.

♿ **Accessibility:**
- Added `aria-labelledby` and `aria-describedby` to link the visually hidden toggle input to its semantic text elements.
- Added `role="status"` and `aria-live="polite"` to the status update message.
- Replaced the banner `div` with a semantic `<button>` ensuring native Tab and Space/Enter support, and added an `aria-label`.
- Added `:focus-visible` CSS rules to the visually hidden input to render a highly visible outline around its styled toggle track sibling.

---
*PR created automatically by Jules for task [15901173762353501862](https://jules.google.com/task/15901173762353501862) started by @Zebfred*