### PR TITLE
⚡ Bolt: Use bulk_write for MongoDB raw event ingestion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,6 @@
 ## 2026-04-30 - Optimize audit inspector database writes with MongoDB bulk_write
 **Learning:** In MongoDB, iterative updates within loops using `update_one` cause multiple network roundtrips, which can become a major latency bottleneck, especially for batch operations.
 **Action:** Replace multiple `update_one` calls inside loops with batched `UpdateOne` objects and execute them in a single `bulk_write(ops, ordered=False)` call outside the loop to minimize network roundtrips.
+## 2024-05-18 - Bulk MongoDB Upserts
+**Learning:** Iterative MongoDB updates (e.g., calling `update_one` inside a loop) cause significant performance overhead due to repeated network roundtrips, specifically during bulk ingestion like Google Calendar raw sync.
+**Action:** Replace sequential iterative updates with a batched approach using `collection.bulk_write()` combined with `pymongo.UpdateOne` or `InsertOne` to minimize database latency and connections.

--- a/src/database/calendar_raw_sync_to_mongo.py
+++ b/src/database/calendar_raw_sync_to_mongo.py
@@ -10,7 +10,7 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
-from pymongo import MongoClient
+from pymongo import MongoClient, UpdateOne
 from datetime import datetime, timedelta, timezone, UTC
 
 from src.integrations.google_calendar_authentication_helper import get_calendar_credentials
@@ -109,6 +109,10 @@ class SovereignCalendarSync:
                 logger.info("No new events found.")
                 break
 
+            # Bolt Optimization: Replaced iterative `update_one` with `bulk_write` to minimize network roundtrips.
+            # This significantly reduces latency when ingesting large numbers of raw events from the Google Calendar API.
+            bulk_ops = []
+
             for event in events:
                 event_id = event.get('id')
                 
@@ -125,11 +129,13 @@ class SovereignCalendarSync:
                     "classification_verified": False
                 }
 
-                # Upsert into MongoDB based on GCal Unique ID and user_email
-                self.raw_collection.update_one(
-                    {"gcal_id": event_id},
-                    {"$set": payload},
-                    upsert=True
+                # Queue upsert into MongoDB based on GCal Unique ID and user_email
+                bulk_ops.append(
+                    UpdateOne(
+                        {"gcal_id": event_id},
+                        {"$set": payload},
+                        upsert=True
+                    )
                 )
                 
                 # 2. Native Time-Series Dual-Write
@@ -137,6 +143,9 @@ class SovereignCalendarSync:
                 
                 # Increment operation count
                 ops_count += 1
+
+            if bulk_ops:
+                self.raw_collection.bulk_write(bulk_ops)
 
             page_token = events_result.get('nextPageToken')
             if not page_token:


### PR DESCRIPTION
💡 **What**: Replaced the iterative `update_one` query inside the `_execute_pull` loop of `SovereignCalendarSync` with a queued list of `UpdateOne` commands, executing a single `bulk_write` per API page response.
🎯 **Why**: When processing large batches of events from the Google Calendar API, calling `update_one` sequentially inside the loop generates significant network overhead (N+1 queries style latency) for the database. Accumulating them into a bulk operation drops network roundtrips to O(1) per page.
📊 **Impact**: Reduces latency during mass raw event ingestion dramatically while preserving identical `upsert=True` payload logic.
🔬 **Measurement**: Verified the syntax using `py_compile` and tested using `pytest tests/unit` to ensure no related schemas or routes break from the change. Added Bolt journal learning.

---
*PR created automatically by Jules for task [6838313904458608170](https://jules.google.com/task/6838313904458608170) started by @Zebfred*