### PR TITLE
⚡ Bolt: Optimize calendar sync via MongoDB bulk_write

### DIFF
--- a/src/database/calendar_raw_sync_to_mongo.py
+++ b/src/database/calendar_raw_sync_to_mongo.py
@@ -10,7 +10,7 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
-from pymongo import MongoClient
+from pymongo import MongoClient, UpdateOne
 from datetime import datetime, timedelta, timezone, UTC
 
 from src.integrations.google_calendar_authentication_helper import get_calendar_credentials
@@ -109,6 +109,7 @@ class SovereignCalendarSync:
                 logger.info("No new events found.")
                 break
 
+            raw_ops = []
             for event in events:
                 event_id = event.get('id')
                 
@@ -126,10 +127,12 @@ class SovereignCalendarSync:
                 }
 
                 # Upsert into MongoDB based on GCal Unique ID and user_email
-                self.raw_collection.update_one(
-                    {"gcal_id": event_id},
-                    {"$set": payload},
-                    upsert=True
+                raw_ops.append(
+                    UpdateOne(
+                        {"gcal_id": event_id},
+                        {"$set": payload},
+                        upsert=True
+                    )
                 )
                 
                 # 2. Native Time-Series Dual-Write
@@ -137,6 +140,11 @@ class SovereignCalendarSync:
                 
                 # Increment operation count
                 ops_count += 1
+
+            # ⚡ Bolt Optimization: Replace O(N) update_one calls with a single O(1) bulk_write
+            # to drastically reduce network round-trips and database latency.
+            if raw_ops:
+                self.raw_collection.bulk_write(raw_ops, ordered=False)
 
             page_token = events_result.get('nextPageToken')
             if not page_token:


### PR DESCRIPTION
💡 **What**: Replaced sequential `update_one` MongoDB calls within the `_execute_pull` sync loop with a single `bulk_write` using an accumulated list of `UpdateOne` operations.
🎯 **Why**: Executing individual database writes sequentially inside a loop introduces severe N+1 query performance problems, causing unnecessary latency due to redundant network round-trips for every single event pulled from Google Calendar.
📊 **Impact**: Reduces network overhead from O(N) database requests down to O(1) request per API page response, drastically improving the throughput of the landing zone sync.
🔬 **Measurement**: Measure the total execution time of `sync.pull_historical_backlog` or `sync.pull_sliding_window` before and after this change. With bulk processing, large multi-page pulls (e.g. 90-day sync) should complete measurably faster. Unit tests ensure behavior is preserved precisely.

---
*PR created automatically by Jules for task [11602013779541484489](https://jules.google.com/task/11602013779541484489) started by @Zebfred*