### PR TITLE
Fix hallucinated method call and missing tenant arguments in agent pipeline

### DIFF
--- a/src/agents/first_serving_porter.py
+++ b/src/agents/first_serving_porter.py
@@ -116,13 +116,13 @@ def chroma_vibe_check(query: str) -> str:
     return f"[DATABASE RETURN] Conceptual Vibe matches:\n{compiled}"
 
 @tool
-def fetch_unverified_audits() -> str:
+def fetch_unverified_audits(user_email: str = "Hero") -> str:
     """Use this to pull any categorized events that the human has not verified yet.
     You will use this to generate the presentation bundle for the Verification Dashboard.
     """
     from src.agents.audit_inspector import AuditInspector
     inspector = AuditInspector()
-    records = inspector.batch_unverified_records()
+    records = inspector.batch_unverified_records(user_email=user_email)
     if not records:
          return "[AUDIT RETURN] No unverified events found. The Verification Dashboard is clean."
     

--- a/src/database/calendar_raw_sync_to_mongo.py
+++ b/src/database/calendar_raw_sync_to_mongo.py
@@ -167,5 +167,5 @@ class SovereignCalendarSync:
 if __name__ == "__main__":
     sync = SovereignCalendarSync()
     # Perform a 90-day pull for verification tonight
-    sync.pull_large_batch(days=90)
+    sync.pull_historical_backlog(user_email="Hero")
     sync.verify_landing_zone()


### PR DESCRIPTION
🎯 **What**
Fixed a critical bug where `first_serving_porter.py` called `batch_unverified_records` without the required `user_email` argument. Also fixed `calendar_raw_sync_to_mongo.py` calling a hallucinated method `pull_large_batch`.

💡 **Why**
These issues caused silent pipeline failures and broke the Verification Dashboard boundary, preventing proper data processing and multi-tenant scaling.

✅ **Verification**
Ran `GOOGLE_CLIENT_USER_LOGIN_ID=test_id uv run pytest tests/unit/` locally to ensure all unit tests pass without regressions.

✨ **Result**
The calendar sync pipeline now correctly uses `pull_historical_backlog`, and the `fetch_unverified_audits` tool passes the necessary tenant identifier through the agent pipeline.

---
*PR created automatically by Jules for task [13546051905651952](https://jules.google.com/task/13546051905651952) started by @Zebfred*