### PR TITLE
⚡ Bolt: Batch sync calendar events using bulk operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,6 @@
 ## 2026-04-30 - Optimize audit inspector database writes with MongoDB bulk_write
 **Learning:** In MongoDB, iterative updates within loops using `update_one` cause multiple network roundtrips, which can become a major latency bottleneck, especially for batch operations.
 **Action:** Replace multiple `update_one` calls inside loops with batched `UpdateOne` objects and execute them in a single `bulk_write(ops, ordered=False)` call outside the loop to minimize network roundtrips.
+## 2024-03-24 - MongoDB Sync Bottleneck (O(N) vs BulkWrite)
+**Learning:** In heavily looping network tasks (like processing hundreds of returned Google Calendar events), sequentially triggering downstream updates inside the loop causes massive network round-trip overhead and bottlenecks database IO.
+**Action:** Extract database writes out of sequential processing loops. Accumulate the payloads in an array and dispatch them using a single PyMongo `bulk_write()` or `insert_many()` transaction for an O(1) network operation.

--- a/src/database/calendar_raw_sync_to_mongo.py
+++ b/src/database/calendar_raw_sync_to_mongo.py
@@ -135,11 +135,11 @@ class SovereignCalendarSync:
                     )
                 )
                 
-                # 2. Native Time-Series Dual-Write
-                success = self.ts_client.stage_raw_event(event, user_email=user_email)
-                
                 # Increment operation count
                 ops_count += 1
+
+            # 2. Native Time-Series Dual-Write (Batched)
+            self.ts_client.stage_raw_events(events, user_email=user_email)
 
             # ⚡ Bolt Optimization: Replace O(N) update_one calls with a single O(1) bulk_write
             # to drastically reduce network round-trips and database latency.

--- a/src/database/mongo_client/calendar_timeseries.py
+++ b/src/database/mongo_client/calendar_timeseries.py
@@ -84,3 +84,65 @@ class CalendarTimeseriesClient:
         except Exception as e:
            logger.info(f"Error processing event {gcal_id}: {e}")
            return False
+
+    def stage_raw_events(self, gcal_events: list, user_email: str = "Hero") -> bool:
+        """
+        Batch upserts the completely raw JSON from google calendar into the timeseries collection.
+        Automatically triggers the downstream processor to route to intent/actual schemas in batch.
+        """
+        if not gcal_events:
+            return True
+
+        payloads = []
+        valid_events = []
+
+        for gcal_event in gcal_events:
+            gcal_id = gcal_event.get('id')
+            if not gcal_id:
+                continue
+
+            # Parse Google Calendar start time to python datetime for timeField
+            start_raw = gcal_event.get('start', {}).get('dateTime') or gcal_event.get('start', {}).get('date')
+            if not start_raw:
+                continue
+
+            try:
+                if start_raw.endswith('Z'):
+                    start_raw = start_raw.replace('Z', '+00:00')
+                start_dt = datetime.fromisoformat(start_raw)
+            except Exception as e:
+                logger.warning(f"Failed to parse event start time '{start_raw}' for event {gcal_id}, defaulting to now: {e}")
+                start_dt = datetime.now(timezone.utc)
+
+            payload = {
+                "start_time": start_dt,
+                "metadata": {
+                    "gcal_id": str(gcal_id),
+                    "user_email": user_email,
+                    "sync_status": "staged",
+                    "event_type": str(gcal_event.get("eventType", "default"))
+                },
+                "raw_data": gcal_event,
+                "porter_ingested_at": datetime.now(timezone.utc)
+            }
+
+            payloads.append(payload)
+            valid_events.append(gcal_event)
+
+        if not payloads:
+            return True
+
+        # Insert as a true timeseries historical event audit log
+        try:
+            self.timeseries_col.insert_many(payloads)
+        except Exception as e:
+            logger.info(f"Failed to bulk insert timeseries events: {e}")
+            return False
+
+        # Trigger downstream processor to split into schemas in batch
+        try:
+           self.processor.process_and_route_events(valid_events, user_email)
+           return True
+        except Exception as e:
+           logger.info(f"Error batch processing events: {e}")
+           return False

--- a/src/database/mongo_client/event_processor.py
+++ b/src/database/mongo_client/event_processor.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import os
 
 from src.config import MongoConfig
+from pymongo import UpdateOne
 from src.database.mongo_client.connection import MongoConnectionManager
 from src.database.mongo_client.uuid_manager import UUIDGenerator
 from src.integrations.calendar_parser import determine_category, event_record_type
@@ -122,3 +123,99 @@ class EventProcessorClient:
         )
         
         return event_uuid
+
+    def process_and_route_events(self, raw_gcal_events: list, user_email: str):
+        """
+        Batch processing of raw json from the Timeseries collection.
+        Parses and routes multiple events to the correct Intent/Actual/Unified representations using bulk_write.
+        """
+        if not raw_gcal_events:
+            return []
+
+        intent_ops = []
+        unified_ops = []
+        event_uuids = []
+
+        for raw_gcal_event in raw_gcal_events:
+            gcal_id = raw_gcal_event.get('id')
+            if not gcal_id:
+                continue
+
+            event_uuid = UUIDGenerator.generate_for_event(gcal_id, user_email)
+
+            # 1. Parse base details
+            start_str = raw_gcal_event.get('start', {}).get('dateTime') or raw_gcal_event.get('start', {}).get('date')
+            end_str = raw_gcal_event.get('end', {}).get('dateTime') or raw_gcal_event.get('end', {}).get('date')
+
+            if not start_str or not end_str:
+                continue
+
+            start_dt = parser.parse(start_str)
+            end_dt = parser.parse(end_str)
+            duration_mins = int((end_dt - start_dt).total_seconds() / 60)
+
+            title = raw_gcal_event.get('summary', 'Untitled')
+            color_id = raw_gcal_event.get('colorId', '1')
+
+            # Determine category (Pillar/Subcategory)
+            category_data = determine_category(title, color_id)
+
+            # Build Standard Payload Block
+            base_payload = {
+                "title": title,
+                "pillar_id": category_data.get("pillar"),
+                "subcategory": category_data.get("subcategory"),
+                "duration_minutes": duration_mins
+            }
+
+            # Time slot
+            time_slot = {
+                "start": start_dt.isoformat(),
+                "end": end_dt.isoformat()
+            }
+
+            intent_ops.append(
+                UpdateOne(
+                    {"_id": event_uuid},
+                    {"$set": {
+                        "user_id": user_email,
+                        "gcal_id": gcal_id,
+                        "time_slot": time_slot,
+                        "intent": base_payload,
+                        "metadata": {
+                            "source": "google_calendar",
+                            "last_sync": datetime.now(timezone.utc).isoformat()
+                        }
+                    }},
+                    upsert=True
+                )
+            )
+
+            unified_update = {
+                "$set": {
+                    "user_id": user_email,
+                    "time_slot": time_slot,
+                    "intent": base_payload,
+                    "metadata": {
+                        "source": "google_calendar",
+                        "last_sync": datetime.now(timezone.utc).isoformat()
+                    }
+                }
+            }
+
+            unified_ops.append(
+                UpdateOne(
+                    {"_id": event_uuid},
+                    unified_update,
+                    upsert=True
+                )
+            )
+
+            event_uuids.append(event_uuid)
+
+        if intent_ops:
+            self.intent_col.bulk_write(intent_ops, ordered=False)
+        if unified_ops:
+            self.unified_col.bulk_write(unified_ops, ordered=False)
+
+        return event_uuids


### PR DESCRIPTION
Implemented bulk database write operations to significantly reduce network roundtrips during calendar event syncing.

💡 **What**: Created batched equivalents `stage_raw_events` and `process_and_route_events` using `insert_many` and `bulk_write` inside `src/database/mongo_client/event_processor.py` and `calendar_timeseries.py`, and refactored the main sync loop in `src/database/calendar_raw_sync_to_mongo.py` to use them.
🎯 **Why**: Replaced O(N) sequential database inserts/updates with O(1) batch payloads to eliminate extreme network IO bottlenecking when fetching rolling sync windows from Google Calendar API.
📊 **Impact**: Expected to reduce database round-trips linearly corresponding to the number of events fetched. A 30-day sync pulling 100 events goes from 300+ database trips down to ~3.
🔬 **Measurement**: Verify via database query response times during standard sync. All local linters and unit tests pass to guarantee correct database semantics are maintained.

---
*PR created automatically by Jules for task [16427562083158835238](https://jules.google.com/task/16427562083158835238) started by @Zebfred*