### PR TITLE
🎨 Palette: Add explicit label to weekly expectation textarea

### DIFF
--- a/frontend/Adventure_Time_log.html
+++ b/frontend/Adventure_Time_log.html
@@ -42,6 +42,7 @@
                     Save Expectation
                 </button>
             </div>
+            <label for="weekly-expectation-text" class="sr-only">Weekly Expectation</label>
             <textarea id="weekly-expectation-text" rows="3" class="w-full bg-white border border-indigo-200 rounded-lg p-3 focus:ring-2 focus:ring-indigo-500 outline-none text-gray-700" placeholder="Set your high-level aim for this week. What does success look like across your pillars?"></textarea>
             <div id="weekly-expectation-status" class="hidden text-green-600 font-bold text-sm mt-2 animate-pulse">
                 Expectation saved to Graph ✅


### PR DESCRIPTION
💡 **What**: Added a visually hidden explicit `<label>` (`.sr-only`) to the `weekly-expectation-text` `<textarea>` element in `Adventure_Time_log.html`.
🎯 **Why**: To adhere to strict accessibility guidelines ensuring that all forms and input fields have clear, programmatically associated labels for screen reader support. This resolves a known issue pattern where textareas were lacking labels.
📸 **Before/After**: The visual layout remains entirely unchanged, as the label utilizes the `sr-only` class.
♿ **Accessibility**: Significant improvement for users relying on screen readers, as the "Weekly Expectation" textarea is now properly announced with its intended purpose.

---
*PR created automatically by Jules for task [4714827337515755281](https://jules.google.com/task/4714827337515755281) started by @Zebfred*