### PR TITLE
🎨 Palette: Add loading state to Porter chat button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,6 @@
 ## 2024-05-19 - Ensure textareas have labels
 **Learning:** Textareas generated dynamically in JavaScript (like the gap-input textarea in user_hub.js) lacked associated labels, making them invisible to screen readers or confusing for assistive tech.
 **Action:** Always ensure every `<textarea>` element, not just `<input>` elements, has an explicit `<label>` with a matching `for` attribute. Use `.sr-only` if the label shouldn't be visually displayed.
+## 2024-05-19 - Missing loading states on async actions
+**Learning:** Found that long-running async actions (like the chat feature in `user_hub.js`) lacked visual loading feedback, allowing users to rapidly double-click buttons resulting in duplicate API requests and no perceived performance response.
+**Action:** Always verify that interactive buttons that trigger async `fetch` requests temporarily update their text (e.g., "Sending...") or display a spinner, and add the `disabled` attribute to prevent double-submission while awaiting a response. Restore the original state within a `finally` block to ensure errors don't permanently disable the interface.

--- a/frontend/js/user_hub.js
+++ b/frontend/js/user_hub.js
@@ -65,6 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
         appendMessage('user', message);
         chatInput.value = '';
         chatInput.disabled = true;
+
+        const originalText = sendButton.innerText;
+        sendButton.innerText = 'Sending...';
         sendButton.disabled = true;
 
         // Show a temporary "Thinking" indicator
@@ -110,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
             appendMessage('porter', 'Sorry, I encountered an issue connecting to my core logic module.');
         } finally {
             chatInput.disabled = false;
+            sendButton.innerText = originalText;
             sendButton.disabled = false;
             chatInput.focus();
         }


### PR DESCRIPTION
💡 **What**: Added a temporary 'Sending...' visual loading state to the Porter Chat submit button during async `sendMessage` fetch requests.
🎯 **Why**: Previously, the chat submit button became disabled during an async request but provided no visual feedback that a process was occurring. This can lead to a perceived frozen application or unresponsiveness. Changing the text to 'Sending...' immediately informs the user that their request is being handled.
📸 **Before/After**: Button now temporarily changes from "Send" to "Sending..." while disabled and properly reverts after the request concludes.
♿ **Accessibility**: Provides immediate context for why an interactive element was disabled, preventing confusion.

---
*PR created automatically by Jules for task [2557388158978227060](https://jules.google.com/task/2557388158978227060) started by @Zebfred*