### PR TITLE
🎨 Palette: [UX improvement] Add accessible labels to inputs in Adventure Journal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-19 - Missing loading states on async actions
 **Learning:** Found that long-running async actions (like the chat feature in `user_hub.js`) lacked visual loading feedback, allowing users to rapidly double-click buttons resulting in duplicate API requests and no perceived performance response.
 **Action:** Always verify that interactive buttons that trigger async `fetch` requests temporarily update their text (e.g., "Sending...") or display a spinner, and add the `disabled` attribute to prevent double-submission while awaiting a response. Restore the original state within a `finally` block to ensure errors don't permanently disable the interface.
+
+## 2024-05-20 - Missing Labels on Textareas and Inputs in Adventure Journal
+**Learning:** The `Adventure_Journal.html` page lacked explicit `<label>` elements for its date input and textareas, which negatively impacts screen reader users who rely on labeled fields to understand the required input.
+**Action:** Added `.sr-only` labels to these inputs (specifically `weekly-expectation-text`, `journal-date-picker`, and `daily-journal-text`) to provide necessary context for assistive tech while preserving the visual layout.

--- a/frontend/Adventure_Journal.html
+++ b/frontend/Adventure_Journal.html
@@ -33,6 +33,7 @@
                     </div>
                 </div>
                 <div id="weekly-expectation-last-saved" class="text-sm text-gray-500 mb-2 font-medium hidden"></div>
+                <label for="weekly-expectation-text" class="sr-only">Weekly Expectation</label>
                 <textarea id="weekly-expectation-text" rows="3" class="w-full bg-white border border-indigo-200 rounded-lg p-3 focus:ring-2 focus:ring-indigo-500 outline-none text-gray-700" placeholder="Set your high-level aim for this week. What does success look like across your pillars?"></textarea>
                 <div id="weekly-expectation-status" class="hidden text-green-600 font-bold text-sm mt-2 animate-pulse">
                     Expectation saved ✅
@@ -46,6 +47,7 @@
                         <span>📝</span> Daily Reflection
                     </h3>
                     <div class="flex items-center gap-4">
+                        <label for="journal-date-picker" class="sr-only">Journal Date</label>
                         <input type="date" id="journal-date-picker" class="border border-gray-300 rounded-lg p-1.5 text-sm outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 bg-white">
                         <button id="save-journal-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-1.5 px-4 rounded-lg shadow-sm transition active:scale-95 text-sm flex items-center gap-2">
                             <span>💾</span> Save Journal
@@ -53,6 +55,7 @@
                     </div>
                 </div>
                 <div id="daily-journal-last-saved" class="text-sm text-gray-500 mb-2 font-medium hidden"></div>
+                <label for="daily-journal-text" class="sr-only">Daily Journal</label>
                 <textarea id="daily-journal-text" rows="15" class="w-full bg-gray-50 border border-gray-300 rounded-lg p-4 focus:ring-2 focus:ring-blue-500 outline-none text-gray-800 font-medium" placeholder="Write your thoughts for the day..."></textarea>
                 <div id="journal-status" class="hidden text-green-600 font-bold text-sm mt-2 animate-pulse">
                     Journal saved ✅


### PR DESCRIPTION
💡 **What:** Added screen-reader-only (`.sr-only`) labels to three previously unlabeled input fields in `frontend/Adventure_Journal.html`: `weekly-expectation-text`, `journal-date-picker`, and `daily-journal-text`.

🎯 **Why:** These input fields lacked associated `<label>` elements, rendering them inaccessible or confusing for users utilizing screen readers or other assistive technologies, as the input's purpose would not be announced correctly.

📸 **Before/After:** No visual changes. The added elements are completely hidden visually via the standard Tailwind `.sr-only` utility class.

♿ **Accessibility:** This ensures that all form inputs on the Adventure Journal page have correct programmatic context for screen readers and satisfies standard semantic HTML best practices.

---
*PR created automatically by Jules for task [7154257412369258946](https://jules.google.com/task/7154257412369258946) started by @Zebfred*