### PR TITLE
⚡ Bolt: Optimize MongoDB temporal index creation by leveraging config variables

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2025-02-23 - Batch Updates in Timeseries Collection (Event Processor)
 **Learning:** When replacing sequential `update_one`/`update_many` calls inside a loop with bulk operations, it is easy to accidentally drop updates for auxiliary collections (like `timeseries_col` closing the loop) if they aren't explicitly migrated to a corresponding ops array.
 **Action:** Ensure all sequential operations from the original single-event routing method are mapped exactly to their batch counterpart `bulk_write` operations, otherwise backend integrity breaks.
+## 2026-06-12 - Index Creation Hardcoded Collection Names
+**Learning:** Index definitions should be tied to configuration variables (`MongoConfig`) instead of hardcoded strings to avoid missing indexes on new collection names after schema changes, preventing full collection scans. Also, temporal queries should use `DESCENDING` indexes for optimal performance.
+**Action:** Always use constants from the config classes (e.g., `MongoConfig.INTENT_COLLECTION`) when creating database indexes, and map time-based sorting to `DESCENDING` (-1).

--- a/src/database/mongo_storage.py
+++ b/src/database/mongo_storage.py
@@ -37,7 +37,7 @@ class SovereignMongoStorage:
 
     def _ensure_indexes(self):
         """Create compound indexes to speed up multi-tenant queries."""
-        from pymongo import ASCENDING
+        from pymongo import ASCENDING, DESCENDING
 
         # In the Timeseries (raw events), index on email + start time for quick window querying
         self.raw_col.create_index([("metadata.user_email", ASCENDING), ("start_time", ASCENDING)])
@@ -46,9 +46,9 @@ class SovereignMongoStorage:
         self.formatted_col.create_index([("user_email", ASCENDING), ("start.dateTime", ASCENDING)])
 
         # Intent and Actual collections for quick queries
-        self.db['calendar_intent_events'].create_index([("user_id", ASCENDING), ("time_slot.start", ASCENDING)])
-        self.db['calendar_actual_events'].create_index([("user_id", ASCENDING), ("time_slot.start", ASCENDING)])
-        self.db['calendar_unified_events'].create_index([("user_id", ASCENDING), ("time_slot.start", ASCENDING)])
+        self.db[MongoConfig.INTENT_COLLECTION].create_index([("user_id", ASCENDING), ("time_slot.start", DESCENDING)])
+        self.db[MongoConfig.ACTUAL_COLLECTION].create_index([("user_id", ASCENDING), ("time_slot.start", DESCENDING)])
+        self.db[MongoConfig.UNIFIED_EVENTS_COLLECTION].create_index([("user_id", ASCENDING), ("time_slot.start", DESCENDING)])
 
     def save_journal_entry(self, log_data: dict, user_id: str = "Hero", correlation_id: str = None):
         """


### PR DESCRIPTION
💡 **What:** 
Updated MongoDB index creation scripts in `SovereignMongoStorage._ensure_indexes` to target the active temporal collections via `MongoConfig` constants and inverted the temporal `time_slot.start` field index from `ASCENDING` to `DESCENDING`.

🎯 **Why:** 
The application was silently missing indexes because the target collection strings (`calendar_intent_events`, etc.) became obsolete after a schema upgrade and were dropped in `schema_consolidation.py`. Without these indexes on the active collections (like `event_actuals`), MongoDB is forced into full collection scans on frequent temporal querying. Additionally, mapping the index direction (DESCENDING) explicitly aligns with the sorting applied to temporal queries, optimizing read performance.

📊 **Impact:** 
Eliminates O(N) full collection scans during common time-based event fetch operations (e.g. `unified_events.find(...)`), forcing them into highly performant B-Tree index scans. 

🔬 **Measurement:** 
Run local tests via `uv run pytest tests/unit/` to verify config availability and application bootstrapping integrity. Observe index metadata manually on MongoDB instances to verify that `event_intentions`, `event_actuals`, and `unified_events` feature compound indices matching the schema `{ user_id: 1, "time_slot.start": -1 }`.

---
*PR created automatically by Jules for task [14404668159103789867](https://jules.google.com/task/14404668159103789867) started by @Zebfred*