### PR TITLE
🎨 Palette: Accessibility improvements for form labels and emojis

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,6 @@
 ## 2024-05-19 - Missing loading states on async actions
 **Learning:** Found that long-running async actions (like the chat feature in `user_hub.js`) lacked visual loading feedback, allowing users to rapidly double-click buttons resulting in duplicate API requests and no perceived performance response.
 **Action:** Always verify that interactive buttons that trigger async `fetch` requests temporarily update their text (e.g., "Sending...") or display a spinner, and add the `disabled` attribute to prevent double-submission while awaiting a response. Restore the original state within a `finally` block to ensure errors don't permanently disable the interface.
+## 2024-05-19 - Screen reader support for emojis in custom radio buttons
+**Learning:** Using emojis as visual representations for radio buttons (e.g., mood selectors) causes screen readers to read the emoji characters (which can be confusing or verbose) rather than the intended state.
+**Action:** When using emojis for visual UI, wrap the emoji in a span with `aria-hidden="true"`, and provide an adjacent `<span class="sr-only">` containing the descriptive text for screen readers. Ensure the parent `<label>` uses a `for` attribute pointing to the hidden radio input.

--- a/frontend/js/adventure_calendar.js
+++ b/frontend/js/adventure_calendar.js
@@ -320,20 +320,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 editForm.innerHTML = `
                     <div class="space-y-3">
                         <div>
-                            <label class="block text-xs font-bold text-gray-700 uppercase">Intention</label>
-                            <input type="text" class="w-full border p-1.5 rounded text-sm" value="${escapeHTML(chunk.intention || '')}" data-field="intention">
+                            <label for="edit-intention-${chunkId}" class="block text-xs font-bold text-gray-700 uppercase cursor-pointer">Intention</label>
+                            <input id="edit-intention-${chunkId}" type="text" class="w-full border p-1.5 rounded text-sm" value="${escapeHTML(chunk.intention || '')}" data-field="intention">
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-gray-700 uppercase">Actual</label>
-                            <input type="text" class="w-full border p-1.5 rounded text-sm" value="${escapeHTML(chunk.actual || '')}" data-field="actual">
+                            <label for="edit-actual-${chunkId}" class="block text-xs font-bold text-gray-700 uppercase cursor-pointer">Actual</label>
+                            <input id="edit-actual-${chunkId}" type="text" class="w-full border p-1.5 rounded text-sm" value="${escapeHTML(chunk.actual || '')}" data-field="actual">
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-gray-700 uppercase">Brain Fog (0-100)</label>
-                            <input type="number" class="w-full border p-1.5 rounded text-sm" value="${chunk.brainFog || 0}" data-field="brainFog">
+                            <label for="edit-brainFog-${chunkId}" class="block text-xs font-bold text-gray-700 uppercase cursor-pointer">Brain Fog (0-100)</label>
+                            <input id="edit-brainFog-${chunkId}" type="number" class="w-full border p-1.5 rounded text-sm" value="${chunk.brainFog || 0}" data-field="brainFog">
                         </div>
                         <div class="flex gap-4 text-sm">
-                            <label class="flex items-center gap-1"><input type="checkbox" data-field="isValuableDetour" ${chunk.isValuableDetour ? 'checked' : ''}> Valuable Detour</label>
-                            <label class="flex items-center gap-1"><input type="checkbox" data-field="isDetrimentalDetour" ${chunk.isDetrimentalDetour ? 'checked' : ''}> Detrimental Detour</label>
+                            <label for="edit-valuable-${chunkId}" class="flex items-center gap-1 cursor-pointer"><input id="edit-valuable-${chunkId}" type="checkbox" data-field="isValuableDetour" ${chunk.isValuableDetour ? 'checked' : ''}> Valuable Detour</label>
+                            <label for="edit-detrimental-${chunkId}" class="flex items-center gap-1 cursor-pointer"><input id="edit-detrimental-${chunkId}" type="checkbox" data-field="isDetrimentalDetour" ${chunk.isDetrimentalDetour ? 'checked' : ''}> Detrimental Detour</label>
                         </div>
                         <div class="flex justify-end gap-2">
                             <button class="cancel-edit-btn bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1.5 rounded text-sm font-bold">Cancel</button>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -141,7 +141,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 ${['happy', 'neutral', 'sad'].map(feeling => `
                                 <label for="feeling-${day}-${chunkId}-${feeling}" class="cursor-pointer">
                                     <input type="radio" id="feeling-${day}-${chunkId}-${feeling}" name="feeling-${day}-${chunkId}" value="${feeling}" class="peer hidden" ${chunkData.feeling === feeling ? 'checked' : ''}>
-                                    <span class="text-2xl opacity-40 peer-checked:opacity-100 hover:opacity-100 transition">${feeling === 'happy' ? '😊' : feeling === 'neutral' ? '😐' : '😔'}</span>
+                                    <span class="text-2xl opacity-40 peer-checked:opacity-100 hover:opacity-100 transition" aria-hidden="true">${feeling === 'happy' ? '😊' : feeling === 'neutral' ? '😐' : '😔'}</span>
+                                    <span class="sr-only">${feeling}</span>
                                 </label>
                                 `).join('')}
                             </div>


### PR DESCRIPTION
💡 **What:** 
- Added explicit `for` attributes matching unique `id`s for the dynamically injected inputs (Intention, Actual, Brain Fog, Valuable Detour, Detrimental Detour) in `adventure_calendar.js`.
- Added `cursor-pointer` to labels to clarify they are clickable interactive elements.
- Updated the emoji mood radio buttons in `app.js` to include `aria-hidden="true"` on the emoji span and added an adjacent `<span class="sr-only">` with the text representation of the mood.
- Documented a critical learning in `.jules/palette.md` regarding proper screen reader handling of visual emojis.

🎯 **Why:** 
- Explicit `<label>` to `<input>` associations expand the clickable target area and are strictly necessary for screen readers to properly announce the input's purpose.
- Visually using emojis is great for sighted users, but screen readers will often read out complex unicode descriptions (e.g. "smiling face with smiling eyes") instead of the semantic meaning (e.g., "happy"). Hiding the emoji and providing an `sr-only` span guarantees perfect accessibility while maintaining the intended visual design.

📸 **Before/After:**
*(Visual changes are minimal (just mouse cursors), but screen reader interaction is fundamentally improved. Code changes explicitly connect inputs like `<label for="edit-actual-X">` -> `<input id="edit-actual-X">`.)*

♿ **Accessibility:** 
- **Screen Readers:** Emojis are now hidden from the accessibility tree and replaced with clear descriptive text.
- **Hit Targets:** Clicking the text "Intention" or "Actual" in the edit modal now correctly focuses the associated text input field.
- **Interactivity Cues:** Users now see a pointer cursor when hovering over interactive form labels.

---
*PR created automatically by Jules for task [16295641124871533706](https://jules.google.com/task/16295641124871533706) started by @Zebfred*